### PR TITLE
add capability to translate multiple words in a single call

### DIFF
--- a/translate.go
+++ b/translate.go
@@ -1,7 +1,8 @@
 package piglatin
 
 import (
-	"strings"
+        "io"
+        "strings"
 )
 
 const (
@@ -25,4 +26,26 @@ func Translate(in string) string {
 	} else {
 		return in[1:] + first + pigLatinSuffix
 	}
+}
+
+type Writer struct {
+        w io.Writer
+}
+
+func NewWriter(w io.Writer) *Writer {
+
+        return &Writer{w: w}
+}
+
+func (w *Writer) Write(p []byte) (n int, err error) {
+        words := strings.Split(string(p), " ")
+        wordIndex := len(words) - 1
+
+        for n, word := range words {
+                w.w.Write([]byte(Translate(word)))
+                if n < wordIndex {
+                        w.w.Write([]byte(" "))
+                }
+        }
+        return
 }

--- a/translate.go
+++ b/translate.go
@@ -10,6 +10,13 @@ const (
 	firstLetterExceptionSuffix string = "d" + pigLatinSuffix
 )
 
+func TranslateMultiple(in ...string) (results []string) {
+        for _, word := range in {
+                results = append(results, Translate(word))
+        }
+        return
+}
+
 // Translate translates an English word into Pig latin.
 func Translate(in string) string {
 	first := in[0:1]

--- a/translate_test.go
+++ b/translate_test.go
@@ -37,3 +37,10 @@ func TestTranslate(t *testing.T) {
 	}
 
 }
+
+func TestTranslateMultiple(t *testing.T) {
+        expected := []string{"atcay", "eggday"}
+        actual := TranslateMultiple("cat", "egg")
+
+        assert.Equal(t, expected, actual)
+}

--- a/translate_test.go
+++ b/translate_test.go
@@ -1,8 +1,9 @@
 package piglatin
 
 import (
-	"github.com/stretchr/testify/assert"
-	"testing"
+        "bytes"
+        "github.com/stretchr/testify/assert"
+        "testing"
 )
 
 var translateTests = []struct {
@@ -43,4 +44,12 @@ func TestTranslateMultiple(t *testing.T) {
         actual := TranslateMultiple("cat", "egg")
 
         assert.Equal(t, expected, actual)
+}
+
+func TestWriter(t *testing.T) {
+        var b bytes.Buffer
+        pigWriter := NewWriter(&b)
+        pigWriter.Write([]byte("hat egg"))
+
+        assert.Equal(t, "athay eggday", string(b.Bytes()))
 }


### PR DESCRIPTION
I accept your challenge to a pull request. I can tell already that I'm going to be rich for writing this translation software.

I originally thought a variadic function would be a good fit for accepting multiple inputs and I could keep using the existing `Translate` function. However, I wasn't sure what to do with the results. Multiple inputs would mean multiple results and so the function signatures would need to be different.
